### PR TITLE
include plate_id name to the illum.npy files

### DIFF
--- a/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
+++ b/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
@@ -128,10 +128,11 @@ task generate_load_data_csv {
     File? xml_file
     File config_yaml
     File stdout
+    String plate_id = "plate_id"
     String? illum_dir = "/cromwell_root/illum"
 
     # Docker image
-    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.1"
+    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.2"
 
     # Hardware-related inputs
     Int hardware_disk_size_GB = 50
@@ -152,7 +153,7 @@ task generate_load_data_csv {
 
     # run the script
     python /scripts/commands.py pe2-load-data  --index-directory $xml_dir --index-file ~{xml_file} --image-file-path-collection-file ~{stdout} --config-yaml ~{config_yaml} --output-file ~{output_filename}
-    python /scripts/commands.py append-illum-cols --illum-directory ~{illum_dir} --config-yaml ~{config_yaml} --input-csv ~{output_filename} --output-csv ~{output_illum_filename}
+    python /scripts/commands.py append-illum-cols --illum-directory ~{illum_dir} --platte-id ~{plate_id} --config-yaml ~{config_yaml} --input-csv ~{output_filename} --output-csv ~{output_illum_filename}
 
     # view the output
     echo "Output CSV file ================================"
@@ -187,7 +188,7 @@ task scatter_index {
     String splitby_metadata
 
     # Docker image
-    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.1"
+    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.2"
 
     # Hardware-related inputs
     Int hardware_disk_size_GB = 50
@@ -237,7 +238,7 @@ task splitto_scatter {
     String index
 
     # Docker image
-    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.1"
+    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.2"
 
     # Hardware-related inputs
     Int hardware_disk_size_GB = 50
@@ -289,7 +290,7 @@ task filter_csv {
     File? full_load_data_with_illum_csv
 
     # Docker image
-    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.1"
+    String docker_image = "us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.2"
 
     # Hardware-related inputs
     Int hardware_disk_size_GB = 50
@@ -406,11 +407,11 @@ task cellprofiler_pipeline_task {
     String? cellprofiler_docker_image = "cellprofiler/cellprofiler:4.2.1"
 
     # Hardware-related inputs
-    Int hardware_boot_disk_size_GB
+    Int hardware_boot_disk_size_GB = 20
     Int hardware_disk_size_GB = 500
     Int hardware_memory_GB = 16
     Int hardware_cpu_count = 4
-    Int hardware_preemptible_tries
+    Int hardware_preemptible_tries = 2
 
     String tarball_name = "outputs.tar.gz"
 

--- a/cellprofiler_distributed/cp_illumination_pipeline.wdl
+++ b/cellprofiler_distributed/cp_illumination_pipeline.wdl
@@ -36,8 +36,6 @@ workflow cp_illumination_pipeline {
     input:
       all_images_files=directory.file_array,  # from util.gsutil_ls task
       load_data_csv= images_directory + "/load_data.csv",
-      hardware_boot_disk_size_GB = 20,
-      hardware_preemptible_tries = 2,
   }
 
   # Delocalize outputs and create new load_data/load_data_with_illum csv files with the new images

--- a/cellprofiler_distributed/cpd_analysis_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_analysis_pipeline.wdl
@@ -51,8 +51,6 @@ workflow cpd_analysis_pipeline {
       input:
         all_images_files = sp.array_output,
         load_data_csv = sp.output_tiny_csv,
-        hardware_boot_disk_size_GB = 20,
-        hardware_preemptible_tries = 2,
     }
 
     call util.extract_and_gsutil_rsync {

--- a/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
@@ -51,8 +51,6 @@ workflow cpd_max_projection_distributed {
       input:
         all_images_files = sp.array_output,
         load_data_csv = sp.output_tiny_csv,
-        hardware_boot_disk_size_GB = 20,
-        hardware_preemptible_tries = 2,
     }
 
     call util.extract_and_gsutil_rsync {


### PR DESCRIPTION
Include plate_id name to the illum.npy file name in load_data_with_illum.csv during its creation in the workflow `create_load_data`.

It also:

-  Fix issue [#24](https://github.com/broadinstitute/cellprofiler-on-Terra/issues/24): Preemptibles configurable for the long running tasks: cellprofiler_pipeline_task & cytomining.
- Update docker_image for cytominining workflow, new docker image version 0.0.3 include the first stable release of pycytominer (0.1).
- Change `aggregation_operation` default to `mean` to follow [profiling_handbook](https://github.com/cytomining/profiling-handbook/issues/53) and `normalize_method` to `mad_robustize` with `mad_robustize_epsilon = 0` by default to follow pycytominer default [suggestions](https://github.com/cytomining/pycytominer/issues/161).
